### PR TITLE
Add Guides item to Docs

### DIFF
--- a/layouts/docs.hbs
+++ b/layouts/docs.hbs
@@ -22,6 +22,9 @@
                     <li{{#equals path site.docs.api.link}} class="active"{{/equals}}>
                         <a href="{{site.docs.api.link}}">{{site.docs.api.text}}</a>
                     </li>
+                    <li{{#equals path site.docs.guides.link}} class="active"{{/equals}}>
+                        <a href="{{site.docs.guides.link}}">{{site.docs.guides.text}}</a>
+                    </li>
                 </ul>
             </aside>
 

--- a/locale/en/site.json
+++ b/locale/en/site.json
@@ -74,6 +74,10 @@
             "link": "/api/",
             "text": "API"
         },
+        "guides": {
+            "link": "docs/guides/",
+            "text": "Guides"
+        },
         "knowledge": {
             "link": "knowledge",
             "text": "Knowledge Base"


### PR DESCRIPTION
Added the Guides item to both locations: `site.json` and `layouts/docs.hbs`, as per https://github.com/nodejs/new.nodejs.org/pull/254.